### PR TITLE
Switch to devmode to solve a few issues

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dotrun snap
         run: |
           snapcraft --destructive-mode
-          sudo snap install --dangerous dotrun_*.snap
+          sudo snap install --devmode --dangerous dotrun_*.snap
       - name: Run tests
         run: |
           pip3 install pexpect

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![dotrun](https://assets.ubuntu.com/v1/9dcb3655-dotrun.png?w=200)
 
-# A tool for developing Node.js & Python projects
+# A tool for developing Node.js and Python projects
 
 `dotrun` makes use of [snap confinement](https://snapcraft.io/docs/snap-confinement) to provide a predictable sandbox for running Node and Python projects.
 
@@ -29,7 +29,9 @@ $ dotrun --env FOO=bar {script}  # Run {script} with FOO environment variable
 ### Ubuntu
 
 ``` bash
-snap install dotrun
+sudo snap install --beta --devmode dotrun
+echo 'snap refresh --devmode dotrun' | sudo tee -a /etc/cron.hourly/refresh-dotrun
+sudo chmod +x /etc/cron.hourly/refresh-dotrun
 ```
 
 ### MacOS
@@ -40,14 +42,16 @@ First install [multipass](https://multipass.run/), then run:
 # Create multipass instance called "dotrun"
 multipass launch -n dotrun bionic
 
-# Install dotrun snap
-multipass exec dotrun -- sudo snap install dotrun
+# Install dotrun snap, check for updates hourly
+multipass exec dotrun -- sudo snap install --beta --devmode dotrun
+multipass exec dotrun -- sh -c "echo 'snap refresh --devmode dotrun' | sudo tee -a /etc/cron.hourly/refresh-dotrun"
+multipass exec dotrun -- sudo chmod +x /etc/cron.hourly/refresh-dotrun
 
 # Share your home directory with the dotrun multipass VM
-multipass mount $HOME dotrun:/home/ubuntu/share$HOME
+multipass mount $HOME dotrun
 
 # Set up alias in your profile
-echo "alias dotrun='multipass exec dotrun -- /snap/bin/dotrun -C \""'/home/ubuntu/share$(pwd)'"\"'" >> ~/.profile
+echo "alias dotrun='multipass exec dotrun -- /snap/bin/dotrun -C \""'$(pwd)'"\"'" >> ~/.profile
 source ~/.profile
 ```
 

--- a/canonicalwebteam/dotrun/models.py
+++ b/canonicalwebteam/dotrun/models.py
@@ -241,18 +241,26 @@ class Project:
         """
 
         changes = False
-        new_revision = False
 
-        if self.state["snap_revision"] != os.environ.get("SNAP_REVISION"):
-            self.state["snap_revision"] = os.environ.get("SNAP_REVISION")
-            new_revision = True
-
-        if not os.path.isdir(self.pyenv_path) or new_revision:
+        if not os.path.isdir(self.pyenv_path):
             cprint(
                 f"- Creating python environment: {self.pyenv_dir}", "magenta"
             )
-            self.exec(["rm", "-rf", self.pyenv_path])
-            self.exec(["virtualenv", "--copies", self.pyenv_path])
+            python_path = shutil.which("python3")
+            if "SNAP_REVISION" in os.environ:
+                python_path = python_path.replace(
+                    "/snap/dotrun/" + os.environ["SNAP_REVISION"],
+                    "/snap/dotrun/current",
+                )
+            self.exec(
+                [
+                    "virtualenv",
+                    "--copies",
+                    "--python",
+                    python_path,
+                    self.pyenv_path,
+                ]
+            )
 
         if not force:
             cprint("- Checking python dependencies ... ", "magenta", end="")

--- a/scripts/test-snap-in-multipass
+++ b/scripts/test-snap-in-multipass
@@ -23,7 +23,7 @@ multipass exec test-dotrun -- tar -C ./dotrun -xzf dotrun.tar.gz
 # Build and install snap
 multipass exec test-dotrun -- sh -c "rm -rf ./dotrun/dotrun_*.snap"
 multipass exec test-dotrun -- sh -c "cd ./dotrun && snapcraft --destructive-mode"
-multipass exec test-dotrun -- sh -c "sudo snap install --dangerous ./dotrun/dotrun_*.snap"
+multipass exec test-dotrun -- sh -c "sudo snap install --devmode --dangerous ./dotrun/dotrun_*.snap"
 multipass exec test-dotrun -- sudo ln -fs /snap/bin/dotrun /usr/bin/dotrun
 
 # Run tests against installed snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,13 @@
 name: dotrun
 base: core18
-version: '1.0.0-rc5'
-summary: A command-line tool for running projects
+version: '1.0.0'
+summary: A command-line tool for running Node.js and Python projects
 description: |
-  A command-line tool for running projects
+  A command-line tool for running Node.js and Python projects
+  from Canonical's webteam
 
 grade: stable
-confinement: strict
+confinement: devmode
 
 parts:
   node:
@@ -20,6 +21,16 @@ parts:
   dotrun-module:
     plugin: python
     source: .
+    stage-packages:
+      - curl
+      - git
+      - libjpeg-progs
+      - libmagickwand-dev
+      - libpng-dev
+      - libpq-dev
+      - libsodium-dev
+      - optipng
+      - zlib1g-dev
 
 apps:
   dotrun:
@@ -28,8 +39,3 @@ apps:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       LC_CTYPE: C.UTF-8
-    plugs:
-      - home
-      - network
-      - network-bind
-      - process-control


### PR DESCRIPTION
**Summary**

- Switch to `devmode` confinement - which fixes https://github.com/canonical-web-and-design/dotrun/issues/12
- A side effect of `devmode` is that mac users can simply do `multipass mount $HOME dotrun` again
- This will also get gunicorn < 20 working again
- Install many useful system dependencies (git, libjpeg, libpq etc.) - which fixes https://github.com/canonical-web-and-design/dotrun/issues/4
- Python virtualenvs now persist between dotrun upgrades
- Snap now needs to be installed with `--devmode --beta` - mentioned in README

**Detail**

This commit takes the controversial step of using "devmode" confinement instead of "strict" confinement.

While there is no doubt that "strict" confinement is theoretically preferable, "devmode" confinement gives us the same structure ($PATH points to binaries within the snap) but with access to the wider system should we need it.

(Read about the confinement options here: https://snapcraft.io/docs/snap-confinement)

"strict" confinement offers far greater security, but we ran into a couple of insurmountable issues with strict confinement:

- https://forum.snapcraft.io/t/access-to-users-for-dotrun-snap/15459
- https://forum.snapcraft.io/t/python-multiprocessing-permission-denied-in-strictly-confined-snap/15518

The first issue we can work around, and were working around, by mounting the `/User` directory for mac users into somewhere inside `/home/ubuntu` in the multipass VM. This isn't ideal, as any paths that are output in logs will be confusing for the mac users, but it will work.

The second issue, though, is a real blocker. We need to be able to run multiprocessing successfully. Particularly, we need to be able to run black successfully, but access to multiprocessing in general is pretty important.

Given that the audience for this tool is developers in our team, I'm not sure it matters to much to ask them to run `dotrun` in `devmode` - hopefully we can ask them to trust this snap and our projects - and so for now it seems to me to make the most sense to simply ask everyone to install dotrun with `--beta --devmode` flags.

I've also found a way to make the .venv python virtualenv persist successfully through upgrades of the dotrun snap, so it no longer tracks the snap revision in `.dotrun.json`, or regenerates the python env if it encounters a new snap version.

QA
--

``` bash
snap install --devmode --beta dotrun
cd ../ubuntu.com
dotrun build && dotrun serve
```