### PR TITLE
Switch to devmode to solve a few issues

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dotrun snap
         run: |
           snapcraft --destructive-mode
-          sudo snap install --dangerous dotrun_*.snap
+          sudo snap install --devmode --dangerous dotrun_*.snap
       - name: Run tests
         run: |
           pip3 install pexpect

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 ![dotrun](https://assets.ubuntu.com/v1/9dcb3655-dotrun.png?w=200)
 
-# A tool for developing Node.js & Python projects
+# A tool for developing Node.js and Python projects
 
 `dotrun` makes use of [snap confinement](https://snapcraft.io/docs/snap-confinement) to provide a predictable sandbox for running Node and Python projects.
 
 Features:
 
-- Make use of standard `package.json` script entrypoints
+- Make use of standard `package.json` script entrypoints:
+  * `dotrun` runs `yarn run start` within the snap confinement
+  * `dotrun foo` runs `yarn run foo` within the snap confinement
 - Detect changes in `package.json` and only run `yarn install` when needed
 - Detect changes in `requirements.txt` and only run `pip3 install` when needed
 - Run scripts using environment variables from `.env` and `.env.local` files
+- Keep python dependencies in `.venv` in the project folder for easy access
 
 ## Usage
 
@@ -18,9 +21,9 @@ $ dotrun          # Install dependencies and run the `start` script from package
 $ dotrun clean    # Delete `node_modules`, `.venv`, `.dotrun.json`, and run `yarn run clean`
 $ dotrun install  # Force install node and python dependencies
 $ dotrun exec     # Start a shell inside the dotrun environment
-$ dotrun exec {command}  # Run {command} inside the dotrun environment
-$ dotrun {script-name}   # Install dependencies and run `yarn run {script-name}`
-$ dotrun -s {script}  # Run {script} but skip installing dependencies
+$ dotrun exec {command}          # Run {command} inside the dotrun environment
+$ dotrun {script-name}           # Install dependencies and run `yarn run {script-name}`
+$ dotrun -s {script}             # Run {script} but skip installing dependencies
 $ dotrun --env FOO=bar {script}  # Run {script} with FOO environment variable
 ```
 
@@ -29,7 +32,9 @@ $ dotrun --env FOO=bar {script}  # Run {script} with FOO environment variable
 ### Ubuntu
 
 ``` bash
-snap install dotrun
+sudo snap install --beta --devmode dotrun
+echo 'snap refresh --devmode dotrun' | sudo tee -a /etc/cron.hourly/refresh-dotrun
+sudo chmod +x /etc/cron.hourly/refresh-dotrun
 ```
 
 ### MacOS
@@ -40,14 +45,16 @@ First install [multipass](https://multipass.run/), then run:
 # Create multipass instance called "dotrun"
 multipass launch -n dotrun bionic
 
-# Install dotrun snap
-multipass exec dotrun -- sudo snap install dotrun
+# Install dotrun snap, check for updates hourly
+multipass exec dotrun -- sudo snap install --beta --devmode dotrun
+multipass exec dotrun -- sh -c "echo 'snap refresh --devmode dotrun' | sudo tee -a /etc/cron.hourly/refresh-dotrun"
+multipass exec dotrun -- sudo chmod +x /etc/cron.hourly/refresh-dotrun
 
 # Share your home directory with the dotrun multipass VM
-multipass mount $HOME dotrun:/home/ubuntu/share$HOME
+multipass mount $HOME dotrun
 
 # Set up alias in your profile
-echo "alias dotrun='multipass exec dotrun -- /snap/bin/dotrun -C \""'/home/ubuntu/share$(pwd)'"\"'" >> ~/.profile
+echo "alias dotrun='multipass exec dotrun -- /snap/bin/dotrun -C \""'$(pwd)'"\"'" >> ~/.profile
 source ~/.profile
 ```
 
@@ -63,7 +70,7 @@ dotrun serve
 To fully support it you should do the following:
 
 - Add `.dotrun.json` and `.venv` to `.gitignore`
-- Swap `0.0.0.0` with `$(hostname -I)` in `package.json`
+- Swap `0.0.0.0` with `$(hostname -i)` in `package.json`
   - This will allow macOS users to click on the link in the command-line output to find the development server
 - Create a `start` script in `package.json` to do everything needed to set up local development. E.g.:
   `"start": "concurrently 'yarn run watch' 'yarn run serve'"`

--- a/canonicalwebteam/dotrun/__init__.py
+++ b/canonicalwebteam/dotrun/__init__.py
@@ -128,7 +128,7 @@ def cli(args=None):
 
     # By default, run a yarn script
     if dotrun.has_script(command):
-        return dotrun.exec(["yarn", "run", command] + arguments.remainder)
+        return dotrun.yarn_run(command, arguments.remainder)
     else:
         cprint(
             f"\n[ `{command}` script not found in `package.json` ]\n", "red"

--- a/scripts/test-snap-in-multipass
+++ b/scripts/test-snap-in-multipass
@@ -23,7 +23,7 @@ multipass exec test-dotrun -- tar -C ./dotrun -xzf dotrun.tar.gz
 # Build and install snap
 multipass exec test-dotrun -- sh -c "rm -rf ./dotrun/dotrun_*.snap"
 multipass exec test-dotrun -- sh -c "cd ./dotrun && snapcraft --destructive-mode"
-multipass exec test-dotrun -- sh -c "sudo snap install --dangerous ./dotrun/dotrun_*.snap"
+multipass exec test-dotrun -- sh -c "sudo snap install --devmode --dangerous ./dotrun/dotrun_*.snap"
 multipass exec test-dotrun -- sudo ln -fs /snap/bin/dotrun /usr/bin/dotrun
 
 # Run tests against installed snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,13 @@
 name: dotrun
 base: core18
-version: '1.0.0-rc5'
-summary: A command-line tool for running projects
+version: '1.0.0'
+summary: A command-line tool for running Node.js and Python projects
 description: |
-  A command-line tool for running projects
+  A command-line tool for running Node.js and Python projects
+  from Canonical's webteam
 
 grade: stable
-confinement: strict
+confinement: devmode
 
 parts:
   node:
@@ -20,6 +21,16 @@ parts:
   dotrun-module:
     plugin: python
     source: .
+    stage-packages:
+      - curl
+      - git
+      - libjpeg-progs
+      - libmagickwand-dev
+      - libpng-dev
+      - libpq-dev
+      - libsodium-dev
+      - optipng
+      - zlib1g-dev
 
 apps:
   dotrun:
@@ -28,8 +39,3 @@ apps:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       LC_CTYPE: C.UTF-8
-    plugs:
-      - home
-      - network
-      - network-bind
-      - process-control

--- a/tests/test_python_project.py
+++ b/tests/test_python_project.py
@@ -185,5 +185,5 @@ class TestPythonProject(unittest.TestCase):
             ["dotrun", "clean"], stderr=STDOUT
         ).decode()
 
-        self.assertIn("No 'clean' script found", clean_output)
+        self.assertIn("'clean' script not found", clean_output)
         self.assertFalse(os.path.isdir(".venv"))

--- a/tests/test_yarn_project.py
+++ b/tests/test_yarn_project.py
@@ -186,6 +186,6 @@ class TestYarnProject(unittest.TestCase):
             ["dotrun", "clean"], stderr=STDOUT
         ).decode()
 
-        self.assertIn("No 'clean' script found", clean_output)
+        self.assertIn("'clean' script not found", clean_output)
         self.assertFalse(os.path.isdir("node_modules"))
         self.assertFalse(os.path.isfile(".dotrun.json"))


### PR DESCRIPTION
**Same as https://github.com/canonical-web-and-design/dotrun/pull/13, but had to recreate this on the parent project so GH actions would run**

**Summary**

- Switch to `devmode` confinement - which fixes https://github.com/canonical-web-and-design/dotrun/issues/12
- A side effect of `devmode` is that mac users can simply do `multipass mount $HOME dotrun` again
- This will also get gunicorn < 20 working again
- Install many useful system dependencies (git, libjpeg, libpq etc.) - which fixes https://github.com/canonical-web-and-design/dotrun/issues/4
- Python virtualenvs now persist between dotrun upgrades
- Snap now needs to be installed with `--devmode --beta` - mentioned in README

**Detail**

This commit takes the controversial step of using "devmode" confinement instead of "strict" confinement.

While there is no doubt that "strict" confinement is theoretically preferable, "devmode" confinement gives us the same structure ($PATH points to binaries within the snap) but with access to the wider system should we need it.

(Read about the confinement options here: https://snapcraft.io/docs/snap-confinement)

"strict" confinement offers far greater security, but we ran into a couple of insurmountable issues with strict confinement:

- https://forum.snapcraft.io/t/access-to-users-for-dotrun-snap/15459
- https://forum.snapcraft.io/t/python-multiprocessing-permission-denied-in-strictly-confined-snap/15518

The first issue we can work around, and were working around, by mounting the `/User` directory for mac users into somewhere inside `/home/ubuntu` in the multipass VM. This isn't ideal, as any paths that are output in logs will be confusing for the mac users, but it will work.

The second issue, though, is a real blocker. We need to be able to run multiprocessing successfully. Particularly, we need to be able to run black successfully, but access to multiprocessing in general is pretty important.

Given that the audience for this tool is developers in our team, I'm not sure it matters to much to ask them to run `dotrun` in `devmode` - hopefully we can ask them to trust this snap and our projects - and so for now it seems to me to make the most sense to simply ask everyone to install dotrun with `--beta --devmode` flags.

I've also found a way to make the .venv python virtualenv persist successfully through upgrades of the dotrun snap, so it no longer tracks the snap revision in `.dotrun.json`, or regenerates the python env if it encounters a new snap version.

QA
--

``` bash
snap install --devmode --beta dotrun
cd ../ubuntu.com
dotrun build && dotrun serve
```