### PR TITLE
Update the mechanism for getting the IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ dotrun serve
 To fully support it you should do the following:
 
 - Add `.dotrun.json` and `.venv` to `.gitignore`
-- Swap `0.0.0.0` with `$(hostname -i)` in `package.json`
+- Swap `0.0.0.0` with `$(hostname -I | awk '{print $1;}')` in `package.json`
   - This will allow macOS users to click on the link in the command-line output to find the development server
 - Create a `start` script in `package.json` to do everything needed to set up local development. E.g.:
   `"start": "concurrently 'yarn run watch' 'yarn run serve'"`


### PR DESCRIPTION
This updates the recommendation in the README for how to tell the local development server which hostname to listen at.

The important detail is that if dotrun is run within multipass then the server will be run using the IP address of that multipass VM, so that in the server's logs you'll see e.g. "Running on http://10.3.4.5" and be able to click on or copy that address directly to access the server.

This should also work if dotrun is run on the host machine, where it will probably show something like `http://192.168.1.12` or again `http://10.77.44.22`.

Fixes #17 

QA
--

Check out a project, try changing the `serve` command in the `package.json` as per [the instructions in the README of this branch](https://github.com/nottrobin/dotrun/blob/17-hostname-ip-fix/README.md#converting-existing-projects), then run `dotrun serve` and check the output hostname works both within multipass and natively.
