### PR TITLE
MacOS instructions; install black, flake8, ipdb to snap itself

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,3 +4,4 @@ v0.2.3, 2019-07-30 -- Fix some bugs
 v0.2.4, 2019-07-30 -- Fix poetry dependency install
 v1.0.0, 2020-02-25 -- Switch to devmode so black works
 v1.1.0, 2020-03-03 -- Re-enable strict mode with semwraplib.so
+v1.1.1, 2020-03-03 -- Install black, flake8, ipdb in snap rather than virtualenv

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ $ dotrun --env FOO=bar {script}  # Run {script} with FOO environment variable
 sudo snap install dotrun
 ```
 
+### MacOS
+
+On MacOS, `dotrun` should be installed and run inside [a multipass VM](https://multipass.run/), using `sudo snap install dotrun` as above.
+
+Given that file access over a virtual network share [is incredibly slow](https://forums.docker.com/t/file-access-in-mounted-volumes-extremely-slow-cpu-bound/8076) in MacOS, it is recommended to keep your project files inside the multipass VM directly and then share them with your host system from there if you want to open them in a graphical editor.
+
+See @hatched's [guide](https://fromanegg.com/post/2020/02/28/use-ubuntu-on-mac-os-with-multipass/) for how to achieve this setup.
+
 ## Converting existing projects
 
 You should be able to use `dotrun` out-of-the-box in most of our pure-Node or Python projects as follows:

--- a/README.md
+++ b/README.md
@@ -37,12 +37,18 @@ sudo snap install dotrun
 
 ## Converting existing projects
 
-Although you should be able to use `dotrun` out-of-the-box in most of our pure-Node or Python projects as follows:
+You should be able to use `dotrun` out-of-the-box in most of our pure-Node or Python projects as follows:
 
 ``` bash
 dotrun build
 dotrun serve
 ```
+
+**Gunicorn support**
+
+If the project uses Gunicorn, you will need to make sure it's using version 20 or later.
+
+**Updating projects**
 
 To fully support it you should do the following:
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotrun
 base: core18
-version: '1.1.0'
+version: '1.1.1'
 summary: A command-line tool for running Node.js and Python projects
 description: |
   A command-line tool for running Node.js and Python projects

--- a/src/canonicalwebteam/dotrun/models.py
+++ b/src/canonicalwebteam/dotrun/models.py
@@ -304,7 +304,6 @@ class Project:
             if force:
                 self.log.note("Installing python dependencies (forced)")
 
-            self.exec(["pip3", "install", "ipdb", "black", "flake8"])
             self.exec(["pip3", "install", "--requirement", "requirements.txt"])
             self.state["python"] = self._get_python_state()
         else:

--- a/src/setup.py
+++ b/src/setup.py
@@ -13,6 +13,13 @@ setup(
     name="canonicalwebteam.dotrun",
     version="0.0.0",
     packages=["canonicalwebteam.dotrun"],
-    install_requires=["ipdb", "termcolor", "virtualenv", "python-dotenv"],
+    install_requires=[
+        "ipdb",
+        "black",
+        "flake8",
+        "termcolor",
+        "virtualenv",
+        "python-dotenv",
+    ],
     entry_points={"console_scripts": ["dotrun = canonicalwebteam.dotrun:cli"]},
 )


### PR DESCRIPTION
Rather than installing them into the virtualenv every time. This makes the `pip install` when spinning up a project quicker.

I didn't think this would work but it does.

QA
--

``` bash
snap install --candidate dotrun
dotrun version  # check it's 1.1.1
cd ~/Projects/ubuntu.com  # Or any webteam python site
echo "gunicorn==20.0.4" >> requirements.txt
dotrun clean && dotrun build && dotrun serve  # Check server works
dotrun exec black --line-length 79 webapp  # Check black still works
```