### PR TITLE
Add gettext dependency, for django-admin makemessages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,3 +6,4 @@ v1.0.0, 2020-02-25 -- Switch to devmode so black works
 v1.1.0, 2020-03-03 -- Re-enable strict mode with semwraplib.so
 v1.1.1, 2020-03-03 -- Install black, flake8, ipdb in snap rather than virtualenv
 v1.1.5, 2020-03-11 -- Avoid yarn errors with proper access to ~/.npmrc
+v1.1.6, 2020-03-31 -- Add gettext package

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotrun
 base: core18
 
-version: "1.1.5"
+version: "1.1.6"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -35,6 +35,7 @@ parts:
     source: src
     stage-packages:
       - curl
+      - gettext  
       - git
       - libjpeg-progs
       - libmagickwand-dev


### PR DESCRIPTION
Add the `gettext` tool so we can make use of django i18n.

## QA
- Install this version of the snap go to the 360-corp project and try to run `dotrun exec ./manage.py makemessages`