### PR TITLE
v1.1.7: Dependencies for python-gnupg

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,12 +16,13 @@ jobs:
 
       - name: Install dotrun snap
         run: |
-          snapcraft --destructive-mode
+          /snap/bin/snapcraft --destructive-mode
           sudo snap install --dangerous dotrun_*.snap
 
       - name: Run tests
         run: |
           pip3 install pexpect
+          export PATH=/snap/bin:$PATH
           python3 -m unittest discover --verbose --start-directory tests
 
   lint-python:
@@ -29,10 +30,10 @@ jobs:
     name: Lint python
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Install system dependencies
-      run: |
-        sudo pip3 install flake8 black
-    - name: Lint Python
-      run: flake8 . && black --line-length 79 --check .
+      - name: Install system dependencies
+        run: |
+          sudo pip3 install flake8 black
+      - name: Lint Python
+        run: flake8 . && black --line-length 79 --check .

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,34 +10,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Check for new version
-      run: |
-        current_version=$(curl -s -H 'Snap-Device-Series: 16' https://api.snapcraft.io/v2/snaps/info/dotrun | jq -r '.["channel-map"][0]["version"]')
-        new_version=$(python -c 'import yaml; print(yaml.load(open("snap/snapcraft.yaml"))["version"])')
-        if [ "$current_version" = "$new_version" ]; then
-          echo "Version $current_version already published."
-          exit 1
-        else
-          echo "Version $new_version is newer than $current_version, proceeding."
-        fi
+      - name: Check for new version
+        run: |
+          current_version=$(curl -s -H 'Snap-Device-Series: 16' https://api.snapcraft.io/v2/snaps/info/dotrun | jq -r '.["channel-map"][0]["version"]')
+          new_version=$(python -c 'import yaml; print(yaml.load(open("snap/snapcraft.yaml"))["version"])')
+          if [ "$current_version" = "$new_version" ]; then
+            echo "Version $current_version already published."
+            exit 1
+          else
+            echo "Version $new_version is newer than $current_version, proceeding."
+          fi
 
-    - name: Install Snapcraft
-      run: |
-        sudo snap install snapcraft --classic
-        sudo chown root:root /
+      - name: Install Snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+          sudo chown root:root /
 
-    - name: Build dotrun snap
-      run: |
-        snapcraft --destructive-mode
-        sudo snap install --dangerous *.snap
+      - name: Build dotrun snap
+        run: |
+          /snap/bin/snapcraft --destructive-mode
+          sudo snap install --dangerous *.snap
 
-    - name: Publish snap
-      run: |
-        new_version=$(curl -s -H 'Snap-Device-Series: 16' https://api.snapcraft.io/v2/snaps/info/dotrun | jq -r '.["channel-map"][0]["version"]')
-        echo "$SNAPCRAFT_LOGIN_FILE" | base64 --decode --ignore-garbage > snapcraft.login
-        snapcraft login --with snapcraft.login
-        snapcraft push *.snap --release stable
-      env:
-        SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}
+      - name: Publish snap
+        run: |
+          new_version=$(curl -s -H 'Snap-Device-Series: 16' https://api.snapcraft.io/v2/snaps/info/dotrun | jq -r '.["channel-map"][0]["version"]')
+          echo "$SNAPCRAFT_LOGIN_FILE" | base64 --decode --ignore-garbage > snapcraft.login
+          /snap/bin/snapcraft login --with snapcraft.login
+          /snap/bin/snapcraft push *.snap --release stable
+        env:
+          SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,3 +7,4 @@ v1.1.0, 2020-03-03 -- Re-enable strict mode with semwraplib.so
 v1.1.1, 2020-03-03 -- Install black, flake8, ipdb in snap rather than virtualenv
 v1.1.5, 2020-03-11 -- Avoid yarn errors with proper access to ~/.npmrc
 v1.1.6, 2020-03-31 -- Add gettext package
+v1.1.6, 2020-04-20 -- Dependencies for python-gnupg

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotrun
 base: core18
 
-version: "1.1.6"
+version: "1.1.7"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -36,13 +36,16 @@ parts:
     source: src
     stage-packages:
       - curl
-      - gettext  
+      - gettext
       - git
+      - build-essential
+      - python3-dev
       - libjpeg-progs
       - libmagickwand-dev
       - libpng-dev
       - libpq-dev
       - libsodium-dev
+      - gpg
       - optipng
       - zlib1g-dev
 


### PR DESCRIPTION
This is so we can run and use `python-gnupg` in ubuntu.com, as we need to do for generating encrypted user data for image builder.