### PR TITLE
Update Snap to use core20

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           pip3 install pexpect
           export PATH=/snap/bin:$PATH
-          python3 -m unittest discover --verbose --start-directory tests
+          python3 -m unittest tests.test_empty_project.TestEmptyProject.test_help
 
   lint-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,10 +9,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-
       - name: Install Snapcraft
         run: |
           sudo snap install snapcraft --classic
@@ -25,10 +21,9 @@ jobs:
 
       - name: Run tests
         run: |
-          pip3 install --upgrade pip
           pip3 install pexpect
           export PATH=/snap/bin:$PATH
-          python3 -m unittest tests.test_empty_project.TestEmptyProject.test_help
+          python3 -m unittest discover --verbose --start-directory tests
 
   lint-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,6 +9,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
       - name: Install Snapcraft
         run: |
           sudo snap install snapcraft --classic

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Run tests
         run: |
+          pip3 install --upgrade pip
           pip3 install pexpect
           export PATH=/snap/bin:$PATH
           python3 -m unittest tests.test_empty_project.TestEmptyProject.test_help

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,3 +9,4 @@ v1.1.5, 2020-03-11 -- Avoid yarn errors with proper access to ~/.npmrc
 v1.1.6, 2020-03-31 -- Add gettext package
 v1.1.7, 2020-04-20 -- Dependencies for python-gnupg
 v1.1.8, 2020-09-15 -- Update python dependencies
+v1.2.0, 2020-06-29 -- Update snap to use core20

--- a/scripts/test-snap-using-multipass
+++ b/scripts/test-snap-using-multipass
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-multipass launch -n test-dotrun bionic || echo "Skipping..."
+multipass launch -c 4 -m 8G -d 50G -n test-dotrun focal || echo "Skipping..."
 multipass start test-dotrun
 
 # Install snapcraft
@@ -14,7 +14,9 @@ multipass exec test-dotrun -- sudo ln -fs /snap/bin/snapcraft /usr/bin/snapcraft
 # Copy files into VM (remove any old files)
 rm -f /tmp/dotrun.tar.gz
 tar -czf /tmp/dotrun.tar.gz .
-multipass transfer /tmp/dotrun.tar.gz test-dotrun:dotrun.tar.gz
+mv /tmp/dotrun.tar.gz .
+multipass transfer dotrun.tar.gz test-dotrun:dotrun.tar.gz
+rm dotrun.tar.gz
 multipass exec test-dotrun -- rm -rf ./dotrun
 multipass exec test-dotrun -- sudo locale-gen en_GB.UTF-8
 multipass exec test-dotrun -- sudo update-locale LANG=en_GB.UTF-8

--- a/scripts/test-snap-using-multipass
+++ b/scripts/test-snap-using-multipass
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-multipass launch -c 4 -m 8G -d 50G -n test-dotrun focal || echo "Skipping..."
+multipass launch -c 2 -m 4G -d 25G -n test-dotrun focal || echo "Skipping..."
 multipass start test-dotrun
 
 # Install snapcraft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotrun
-base: core18
+base: core20
 
-version: "1.1.9"
+version: "1.2.0"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -34,6 +34,10 @@ parts:
   dotrun-module:
     plugin: python
     source: src
+    build-packages:
+      - gcc-multilib
+    python-packages:
+      - wheel
     stage-packages:
       - curl
       - gettext
@@ -61,12 +65,13 @@ plugs:
 
 apps:
   dotrun:
-    command: dotrun
+    command: bin/dotrun
     environment:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       LC_CTYPE: C.UTF-8
       LD_PRELOAD: $SNAP/lib/semwraplib.so
+      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.8/site-packages:$SNAP/lib/python3.8/dist-packages
     plugs:
       - home
       - network

--- a/src/canonicalwebteam/dotrun/models.py
+++ b/src/canonicalwebteam/dotrun/models.py
@@ -154,6 +154,13 @@ class Project:
         if os.path.isfile(f"{self.pyenv_path}/bin/python3"):
             env["VIRTUAL_ENV"] = self.pyenv_path
             env["PATH"] = self.pyenv_path + "/bin:" + env["PATH"]
+
+            # Update PYTHONPATH for core20
+            env["PYTHONPATH"] = (
+                f"{self.pyenv_path}/lib/python3.8/site-packages:"
+                f"{env['PYTHONPATH']}"
+            )
+
             env.pop("PYTHONHOME", None)
 
             self.log.step(


### PR DESCRIPTION
# Done

- Update dotrun snap to use core20 (Python 3.8)
- It will fix an issue ussing ipdb with dotrun

# QA

```bash
snap remove --purge dotrun
snapcraft clean
snapcraft
snap install --dangerous dotrun_1.2.0_amd64.snap
snap connect dotrun:dot-npmrc
snap connect dotrun:dot-yarnrc
```

Go to any of our website and run the site with dotrun:
`dotrun`

(Optional) Add an ipdb `set_trace` to the site it should work as expected!
