### PR TITLE
Docker support

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,11 @@ jobs:
           export PATH=/snap/bin:$PATH
           python3 -m unittest discover --verbose --start-directory tests
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dotrun-snap
+          path: dotrun_*.snap
+
   lint-python:
     runs-on: ubuntu-latest
     name: Lint python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   test-snap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Test snap
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -33,13 +33,19 @@ $ dotrun --env FOO=bar {script}  # Run {script} with FOO environment variable
 
 ### Ubuntu
 
+The best way to install dotrun with all the requirements is by running the following script:
 ```bash
-sudo snap install dotrun
-sudo snap connect dotrun:dot-npmrc
-sudo snap connect dotrun:dot-yarnrc
+curl -s https://raw.githubusercontent.com/canonical-web-and-design/dotrun/master/scripts/install-dotrun-docker.sh | bash
 ```
 
-Note: The `dotrun:dot-npmrc` and `dotrun:dot-yarnrc` [plugs](https://snapcraft.io/docs/interface-management) gives the snap access to read the `~/.npmrc` and `~/.yarnrc` files in your home directory. This is only necessary if you have these files on your system, but if they do exist, the snap will fail to run `yarn` unless it's given access.
+**What the script does**
+
+- Add the user to the docker group
+- Install the dotrun snap and the docker snap
+- It will also set the needed [plugs](https://snapcraft.io/docs/interface-management):
+  - `dotrun:dot-npmrc` gives the snap access to read the `~/.npmrc`
+  - `dotrun:dot-yarnrc` gives the snap access to read the `~/.yarnrc`
+  - `dotrun:docker-executables docker:docker-executables dotrun:docker-cli docker:docker-daemon` will make it possible to the dotrun snap to use docker. These docker plugs and the docker snap are optional but needed for projects with `docker-compose.yaml` files.
 
 ### MacOS
 

--- a/scripts/cloud-init-dotrun.yaml
+++ b/scripts/cloud-init-dotrun.yaml
@@ -1,12 +1,10 @@
 #cloud-config
 
 packages:
- - nfs-kernel-server
+  - nfs-kernel-server
 
 runcmd:
-  - snap install dotrun
-  - snap connect dotrun:dot-yarnrc
-  - snap connect dotrun:dot-npmrc
+  - curl -s https://raw.githubusercontent.com/canonical-web-and-design/dotrun/master/scripts/install-dotrun-docker.sh | bash
   - mkdir /home/ubuntu/dotrun-projects
   - chown ubuntu:ubuntu /home/ubuntu/dotrun-projects
   - echo "/home/ubuntu/dotrun-projects $(ip addr | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\/24\b")(rw,fsid=0,insecure,no_subtree_check,all_squash,async,anonuid=1000,anongid=1000)" | tee -a /etc/exports

--- a/scripts/install-dotrun-docker.sh
+++ b/scripts/install-dotrun-docker.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+# Add user to docker group
+sudo addgroup --system docker
+sudo adduser $USER docker
+newgrp docker
+
+# Install docker and dotrun snaps
+sudo snap install docker dotrun
+
+# Do needed snap connects
+sudo snap connect dotrun:dot-npmrc
+sudo snap connect dotrun:dot-yarnrc
+sudo snap connect dotrun:docker-executables docker:docker-executables
+sudo snap connect dotrun:docker-cli docker:docker-daemon

--- a/scripts/test-snap-in-multipass
+++ b/scripts/test-snap-in-multipass
@@ -12,9 +12,7 @@ multipass exec test-dotrun -- sudo snap install snapcraft --classic
 multipass exec test-dotrun -- sudo ln -fs /snap/bin/snapcraft /usr/bin/snapcraft
 
 # Copy files into VM (remove any old files)
-rm -f /tmp/dotrun.tar.gz
-tar -czf /tmp/dotrun.tar.gz .
-multipass transfer /tmp/dotrun.tar.gz test-dotrun:dotrun.tar.gz
+tar -czO . | multipass transfer - test-dotrun:dotrun.tar.gz
 multipass exec test-dotrun -- rm -rf ./dotrun
 multipass exec test-dotrun -- sudo locale-gen en_GB.UTF-8
 multipass exec test-dotrun -- sudo update-locale LANG=en_GB.UTF-8

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotrun
 base: core18
 
-version: "1.1.9"
+version: "1.2.0"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -58,6 +58,13 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.yarnrc
+  docker-cli:
+    interface: docker
+  docker-executables:
+    content: docker-executables
+    default-provider: docker
+    interface: content
+    target: docker-env
 
 apps:
   dotrun:
@@ -67,6 +74,7 @@ apps:
       LC_ALL: C.UTF-8
       LC_CTYPE: C.UTF-8
       LD_PRELOAD: $SNAP/lib/semwraplib.so
+      PYTHONPATH: $PYTHONPATH:/snap/docker/current/lib/python3.6/site-packages/
     plugs:
       - home
       - network
@@ -74,3 +82,5 @@ apps:
       - process-control
       - dot-npmrc
       - dot-yarnrc
+      - docker-cli
+      - docker-executables

--- a/src/canonicalwebteam/dotrun/__init__.py
+++ b/src/canonicalwebteam/dotrun/__init__.py
@@ -10,6 +10,7 @@ from argparse import (
 )
 import os
 import sys
+import time
 
 # Packages
 from termcolor import cprint
@@ -146,10 +147,17 @@ def cli(args=None):
                 dotrun.exec(
                     [
                         docker_compose,
+                        "pull",
+                    ]
+                )
+                dotrun.exec(
+                    [
+                        docker_compose,
                         "up",
                     ],
                     background=True,
                 )
+                time.sleep(2)
 
         try:
             return dotrun.yarn_run(command, arguments.remainder)

--- a/src/canonicalwebteam/dotrun/__init__.py
+++ b/src/canonicalwebteam/dotrun/__init__.py
@@ -127,6 +127,18 @@ def cli(args=None):
     if command == "install":
         return dotrun.install(force=True)
 
+    if command == "start":
+        if os.path.isfile("./docker-compose.yaml") and os.path.isfile(
+            f'{os.environ.get("SNAP")}/docker-env/bin/docker-compose'
+        ):
+            dotrun.exec(
+                [
+                    f'{os.environ.get("SNAP")}/docker-env/bin/docker-compose',
+                    "up",
+                    "-d",
+                ]
+            )
+
     if not arguments.skip_install:
         dotrun.install(force=False)
 


### PR DESCRIPTION
## Done

- Added support for `docker-compose` inside the dotrun snap

Fixes https://github.com/canonical-web-and-design/dotrun/issues/36

## QA Steps

```bash
snap remove --purge dotrun
snapcraft
snap install --dangerous dotrun_1.2.0_amd64.snap

# Make sure your user is part of the docker group
sudo addgroup --system docker
sudo adduser $USER docker
newgrp docker

# Install docker snaps
sudo snap install docker

# Snap connects
sudo snap connect dotrun:dot-npmrc
sudo snap connect dotrun:dot-yarnrc
sudo snap connect dotrun:docker-executables docker:docker-executables
sudo snap connect dotrun:docker-cli docker:docker-daemon
```

- Clone the ubuntu.com project the database should be spin with just `dotrun`