### PR TITLE
Add libjpeg-dev and libmagic1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotrun
 base: core18
 
-version: "1.4.0"
+version: "1.4.1"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -46,7 +46,9 @@ parts:
       - git
       - build-essential
       - python3-dev
+      - libjpeg-dev
       - libjpeg-progs
+      - libmagic1
       - libmagickwand-dev
       - libpng-dev
       - libpq-dev


### PR DESCRIPTION
Add libjpeg-dev and libmagic1 to support developing on assets.ubuntu.com

# QA
- `snapcraft`
- `snap install --dangerous dotrun_1.4.1_multi.snap`
- checkout https://github.com/canonical-web-and-design/assets.ubuntu.com/pull/161
- `docker-compose up -d`
- `dotrun`