### PR TITLE
Upgrade to Python 3.8

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,16 +9,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Snapcraft
-        run: |
-          sudo snap install snapcraft --classic
-          sudo chown root:root /
+      - name: Install Snapcraft with LXD
+        uses: samuelmeuli/action-snapcraft@v1
+        with:
+          use_lxd: true
+
+      - name: Build snap
+        run: sg lxd -c 'snapcraft --use-lxd'
 
       - name: Install dotrun snap
         run: |
           sudo rm -rf /etc/docker
-          /snap/bin/snapcraft --destructive-mode
-          sudo snap install docker
           sudo snap install --dangerous dotrun_*.snap
 
       - name: Run tests

--- a/scripts/local-qa.sh
+++ b/scripts/local-qa.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+rm dotrun_*.snap
+sudo snap remove --purge dotrun
+
+set -e
+
+snapcraft clean
+snapcraft
+snap install --dangerous dotrun_*.snap
+sudo snap connect dotrun:dot-npmrc
+sudo snap connect dotrun:dot-yarnrc
+sudo snap connect dotrun:docker-executables docker:docker-executables
+sudo snap connect dotrun:docker-cli docker:docker-daemon

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,7 @@ description: |
   A command-line tool for running Node.js and Python projects
   from Canonical's webteam
 
+base: core20
 grade: stable
 confinement: strict
 
@@ -17,77 +18,6 @@ architectures:
   - build-on: arm64
 
 parts:
-  # Use custom Python version
-  # More info: https://forum.snapcraft.io/t/build-a-snap-with-any-version-of-python-i-want/10420/6
-  python38:
-    source: https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz
-    source-type: tar
-    source-checksum: md5/e9d6ebc92183a177b8e8a58cad5b8d67
-    plugin: autotools
-    configflags:
-      - --prefix=/usr
-    build-packages:
-      - libbz2-dev
-      - libexpat1-dev
-      - libffi-dev
-      - libgdbm-dev
-      - liblzma-dev
-      - libncurses5-dev
-      - libreadline-dev
-      - libsqlite3-dev
-      - libssl-dev
-      - libzip-dev
-      - uuid-dev
-    stage-packages:
-      - libbz2-1.0
-      - libexpat1
-      - libffi6
-      - libgdbm-dev
-      - liblzma5
-      - libncurses5
-      - libreadline-dev
-      - libsqlite3-0
-      - libssl1.0.0
-      - libzip4
-      - uuid-runtime
-    override-stage: |
-      # We want the latest pip to be able to install pyproject.toml based projects
-      PYTHONUSERBASE="$SNAPCRAFT_PART_INSTALL/usr" python3.8 -m pip install --user --upgrade pip wheel
-
-      # Apply the same shebang rewrite as done by snapcraft
-      find $SNAPCRAFT_PART_INSTALL/usr/bin/ -maxdepth 1 -mindepth 1 -type f -executable -exec \
-        sed -i                                                                                \
-          "s|^#!${SNAPCRAFT_PART_INSTALL}/usr/bin/python3.8$|#!/usr/bin/env python3|" {} \;
-
-      snapcraftctl stage
-    filesets:
-      exclusion:
-        - -etc
-        - -lib/systemd
-        - -usr/bin/2to3
-        - -usr/bin/2to3-3.8
-        - -usr/bin/deb-systemd-helper
-        - -usr/bin/deb-systemd-invoke
-        - -usr/bin/easy_install-3.8
-        - -usr/bin/idle3
-        - -usr/bin/idle3.8
-        - -usr/bin/pip3
-        - -usr/bin/pip3.8
-        - -usr/bin/pydoc3
-        - -usr/bin/pydoc3.8
-        - -usr/bin/python3.8-config
-        - -usr/bin/python3-config
-        - -usr/bin/uuidgen
-        - -usr/include
-        - -usr/lib/*.a
-        - -usr/lib/pkgconfig
-        - -usr/lib/python3.8/test
-        - -usr/sbin
-        - -usr/share
-        - -var
-    prime:
-      - "$exclusion"
-
   node:
     plugin: dump
     source:
@@ -111,6 +41,8 @@ parts:
   dotrun-module:
     plugin: python
     source: src
+    python-packages:
+      - docker-compose
     stage-packages:
       - curl
       - gettext
@@ -127,16 +59,6 @@ parts:
       - gpg
       - optipng
       - zlib1g-dev
-    stage:
-     - -lib/x86_64-linux-gnu/libbz2.so.1.0
-     - -usr/bin/pydoc3
-     - -usr/bin/python3
-     - -usr/bin/python3-config
-     - -usr/lib/python3.8/distutils/*
-     - -usr/lib/python3.8/lib2to3/*
-    after:
-      - python38
-
 plugs:
   dot-npmrc:
     interface: personal-files
@@ -156,15 +78,12 @@ plugs:
 
 apps:
   dotrun:
-    command: dotrun
+    command: bin/dotrun
     environment:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       LC_CTYPE: C.UTF-8
       LD_PRELOAD: $SNAP/lib/semwraplib.so
-      # Needed for docker snap, previous error trace:
-      # https://pastebin.ubuntu.com/p/xyKgPdKNqQ/
-      PYTHONPATH: $PYTHONPATH:/snap/docker/current/lib/python3.8/site-packages/:/snap/docker/current/lib/python3.6/site-packages/
     plugs:
       - home
       - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dotrun
 base: core18
 
-version: "1.4.1"
+version: "1.4.2"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -17,6 +17,77 @@ architectures:
   - build-on: arm64
 
 parts:
+  # Use custom Python version
+  # More info: https://forum.snapcraft.io/t/build-a-snap-with-any-version-of-python-i-want/10420/6
+  python38:
+    source: https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz
+    source-type: tar
+    source-checksum: md5/e9d6ebc92183a177b8e8a58cad5b8d67
+    plugin: autotools
+    configflags:
+      - --prefix=/usr
+    build-packages:
+      - libbz2-dev
+      - libexpat1-dev
+      - libffi-dev
+      - libgdbm-dev
+      - liblzma-dev
+      - libncurses5-dev
+      - libreadline-dev
+      - libsqlite3-dev
+      - libssl-dev
+      - libzip-dev
+      - uuid-dev
+    stage-packages:
+      - libbz2-1.0
+      - libexpat1
+      - libffi6
+      - libgdbm-dev
+      - liblzma5
+      - libncurses5
+      - libreadline-dev
+      - libsqlite3-0
+      - libssl1.0.0
+      - libzip4
+      - uuid-runtime
+    override-stage: |
+      # We want the latest pip to be able to install pyproject.toml based projects
+      PYTHONUSERBASE="$SNAPCRAFT_PART_INSTALL/usr" python3.8 -m pip install --user --upgrade pip wheel
+
+      # Apply the same shebang rewrite as done by snapcraft
+      find $SNAPCRAFT_PART_INSTALL/usr/bin/ -maxdepth 1 -mindepth 1 -type f -executable -exec \
+        sed -i                                                                                \
+          "s|^#!${SNAPCRAFT_PART_INSTALL}/usr/bin/python3.8$|#!/usr/bin/env python3|" {} \;
+
+      snapcraftctl stage
+    filesets:
+      exclusion:
+        - -etc
+        - -lib/systemd
+        - -usr/bin/2to3
+        - -usr/bin/2to3-3.8
+        - -usr/bin/deb-systemd-helper
+        - -usr/bin/deb-systemd-invoke
+        - -usr/bin/easy_install-3.8
+        - -usr/bin/idle3
+        - -usr/bin/idle3.8
+        - -usr/bin/pip3
+        - -usr/bin/pip3.8
+        - -usr/bin/pydoc3
+        - -usr/bin/pydoc3.8
+        - -usr/bin/python3.8-config
+        - -usr/bin/python3-config
+        - -usr/bin/uuidgen
+        - -usr/include
+        - -usr/lib/*.a
+        - -usr/lib/pkgconfig
+        - -usr/lib/python3.8/test
+        - -usr/sbin
+        - -usr/share
+        - -var
+    prime:
+      - "$exclusion"
+
   node:
     plugin: dump
     source:
@@ -56,6 +127,15 @@ parts:
       - gpg
       - optipng
       - zlib1g-dev
+    stage:
+     - -lib/x86_64-linux-gnu/libbz2.so.1.0
+     - -usr/bin/pydoc3
+     - -usr/bin/python3
+     - -usr/bin/python3-config
+     - -usr/lib/python3.8/distutils/*
+     - -usr/lib/python3.8/lib2to3/*
+    after:
+      - python38
 
 plugs:
   dot-npmrc:
@@ -82,7 +162,9 @@ apps:
       LC_ALL: C.UTF-8
       LC_CTYPE: C.UTF-8
       LD_PRELOAD: $SNAP/lib/semwraplib.so
-      PYTHONPATH: $PYTHONPATH:/snap/docker/current/lib/python3.6/site-packages/
+      # Needed for docker snap, previous error trace:
+      # https://pastebin.ubuntu.com/p/xyKgPdKNqQ/
+      PYTHONPATH: $PYTHONPATH:/snap/docker/current/lib/python3.8/site-packages/:/snap/docker/current/lib/python3.6/site-packages/
     plugs:
       - home
       - network

--- a/src/canonicalwebteam/dotrun/__init__.py
+++ b/src/canonicalwebteam/dotrun/__init__.py
@@ -141,9 +141,10 @@ def cli(args=None):
             docker_compose = (
                 f'{os.environ.get("SNAP")}/docker-env/bin/docker-compose'
             )
-            if os.path.isfile("docker-compose.yaml") and os.path.isfile(
-                docker_compose
-            ):
+            if (
+                os.path.isfile("docker-compose.yaml")
+                or os.path.isfile("docker-compose.yml")
+            ) and os.path.isfile(docker_compose):
                 dotrun.exec(
                     [
                         docker_compose,

--- a/src/canonicalwebteam/dotrun/__init__.py
+++ b/src/canonicalwebteam/dotrun/__init__.py
@@ -10,7 +10,6 @@ from argparse import (
 )
 import os
 import sys
-import time
 
 # Packages
 from termcolor import cprint
@@ -19,8 +18,8 @@ from termcolor import cprint
 from canonicalwebteam.dotrun.models import Project
 
 
-DOTRUN_COMPOSE_ACTIONS = os.environ.get(
-    "DOTRUN_COMPOSE_ACTIONS", "start:serve"
+DOTRUN_DOCKER_COMPOSE_ACTIONS = os.environ.get(
+    "DOTRUN_DOCKER_COMPOSE_ACTIONS", "start:serve"
 ).split(":")
 
 
@@ -137,28 +136,9 @@ def cli(args=None):
     # By default, run a yarn script
     if dotrun.has_script(command):
         # Some commands can run docker-compose in the background
-        if command in DOTRUN_COMPOSE_ACTIONS:
-            docker_compose = (
-                f'{os.environ.get("SNAP")}/docker-env/bin/docker-compose'
-            )
-            if (
-                os.path.isfile("docker-compose.yaml")
-                or os.path.isfile("docker-compose.yml")
-            ) and os.path.isfile(docker_compose):
-                dotrun.exec(
-                    [
-                        docker_compose,
-                        "pull",
-                    ]
-                )
-                dotrun.exec(
-                    [
-                        docker_compose,
-                        "up",
-                    ],
-                    background=True,
-                )
-                time.sleep(2)
+        if command in DOTRUN_DOCKER_COMPOSE_ACTIONS:
+            if dotrun._check_docker_compose():
+                dotrun._docker_compose_start()
 
         try:
             return dotrun.yarn_run(command, arguments.remainder)

--- a/src/canonicalwebteam/dotrun/models.py
+++ b/src/canonicalwebteam/dotrun/models.py
@@ -111,8 +111,11 @@ class Project:
             shutil.rmtree("node_modules")
 
         if os.path.isdir(self.pyenv_path):
-            self.log.step("Removing `.venv` python environment")
-            shutil.rmtree(self.pyenv_path)
+            self._clean_python_env()
+
+    def _clean_python_env(self):
+        self.log.step("Removing `.venv` python environment")
+        shutil.rmtree(self.pyenv_path)
 
     def yarn_run(self, script_name, arguments=[], exit_on_error=True):
         """
@@ -156,6 +159,15 @@ class Project:
             env["VIRTUAL_ENV"] = self.pyenv_path
             env["PATH"] = self.pyenv_path + "/bin:" + env["PATH"]
             env.pop("PYTHONHOME", None)
+
+            if not os.path.isfile(f"{self.pyenv_path}/bin/python3.8"):
+                self.log.note(
+                    "Dotrun was updated to use Python 3.8! "
+                    "This project seems to be using a previous Python environment."
+                )
+                self.log.step("Cleaning previous Python environment")
+                self._clean_python_env()
+                self._install_python_dependencies(force=True)
 
             self.log.step(
                 f"$ {' '.join(commands)}",

--- a/src/canonicalwebteam/dotrun/models.py
+++ b/src/canonicalwebteam/dotrun/models.py
@@ -162,10 +162,10 @@ class Project:
 
             if not os.path.isfile(f"{self.pyenv_path}/bin/python3.8"):
                 self.log.note(
-                    "Dotrun was updated to use Python 3.8! "
-                    "This project seems to be using a previous Python environment."
+                    "Dotrun was updated to use Python 3.8! This project "
+                    "seems to be using a previous Python environment."
                 )
-                self.log.step("Cleaning previous Python environment")
+                self.log.step("Creating new Python environment")
                 self._clean_python_env()
                 self._install_python_dependencies(force=True)
 


### PR DESCRIPTION
## Issue

Dotrun is using Python 3.6 and our Docker images are using Python 3.8.2 (https://packages.ubuntu.com/focal/python3)
This inconsistency can create some issues like: https://github.com/canonical-web-and-design/charmhub.io/issues/1158

## Done

Upgrade the snap to use Python 3.8.2.

## QA
### Run the following commands:

1. (Optional) Clean multipass instance (I always need to do it)
```
snapcraft clean
```

2. Build snap
```
snapcraft
```

3. Install
```
snap install --dangerous dotrun_1.4.2_multi.snap
sudo snap connect dotrun:dot-npmrc
sudo snap connect dotrun:dot-yarnrc
sudo snap connect dotrun:docker-executables docker:docker-executables
sudo snap connect dotrun:docker-cli docker:docker-daemon
```

4. Go to any web project and run `dotrun`