### PR TITLE
Fix architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,9 +14,7 @@ confinement: strict
 
 architectures:
   - build-on: amd64
-    run-on: amd64
   - build-on: arm64
-    run-on: arm64
 
 parts:
   node:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,8 +13,10 @@ grade: stable
 confinement: strict
 
 architectures:
-  - build-on: [amd64, arm64]
-    run-on: [amd64, arm64]
+  - build-on: amd64
+    run-on: amd64
+  - build-on: arm64
+    run-on: arm64
 
 parts:
   node:


### PR DESCRIPTION
https://snapcraft.io/docs/architectures says:
> the default value for `run-on` is the value of `build-on`