### PR TITLE
Fix install script

### DIFF
--- a/scripts/cloud-init-dotrun.yaml
+++ b/scripts/cloud-init-dotrun.yaml
@@ -4,7 +4,8 @@ packages:
   - nfs-kernel-server
 
 runcmd:
-  - curl -s https://raw.githubusercontent.com/canonical-web-and-design/dotrun/main/scripts/install-dotrun-docker.sh | bash
+  - curl -s https://raw.githubusercontent.com/canonical-web-and-design/dotrun/main/scripts/install-dotrun-docker.sh --output install-dotrun-docker.sh
+  - bash ./install-dotrun-docker.sh
   - mkdir /home/ubuntu/dotrun-projects
   - chown ubuntu:ubuntu /home/ubuntu/dotrun-projects
   - echo "/home/ubuntu/dotrun-projects $(ip addr | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\/24\b")(rw,fsid=0,insecure,no_subtree_check,all_squash,async,anonuid=1000,anongid=1000)" | tee -a /etc/exports


### PR DESCRIPTION
## Done

- Split `curl -s ... | bash` line into two steps to fix cloud-init installation on multipass. Fixes https://github.com/canonical-web-and-design/dotrun/issues/69
