### PR TITLE
Fix docker-compose detection for -C directory option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,3 +10,4 @@ v1.1.6, 2020-03-31 -- Add gettext package
 v1.1.7, 2020-04-20 -- Dependencies for python-gnupg
 v1.1.8, 2020-09-15 -- Update python dependencies
 v1.3.0, 2021-06-22 -- Bump node to 16.3.0
+v1.4.3, 2022-02-06 -- Fix docker-compose starting with -C option

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,6 @@
 name: dotrun
-base: core18
 
-version: "1.4.2"
+version: "1.4.3"
 
 summary: A command-line tool for running Node.js and Python projects
 

--- a/src/canonicalwebteam/dotrun/models.py
+++ b/src/canonicalwebteam/dotrun/models.py
@@ -361,8 +361,8 @@ class Project:
         """
 
         return (
-            os.path.isfile("docker-compose.yaml")
-            or os.path.isfile("docker-compose.yml")
+            os.path.isfile(f"{self.path}/docker-compose.yaml")
+            or os.path.isfile(f"{self.path}/docker-compose.yml")
         ) and os.path.isfile(DOCKER_COMPOSE_BINARY)
 
     def _docker_compose_start(self):


### PR DESCRIPTION
Fixes #74 

QA
--

You'll need to `snap install snapcraft` if you don't have it.

On mac, do this inside a multipass.

``` shell
$ snapcraft
...
Snapped dotrun_1.4.3_amd64.snap

$ snap install --dangerous dotrun_1.4.3_amd64.snap  # or arm64 or whatever
dotrun 1.4.3 installed

$ dotrun -C path/to/ubuntu.com serve
- Yarn dependencies up to date               
- Python dependencies up to date                                                                                                                                                                            
                                                                                                      
[ $ /snap/dotrun/x2/docker-env/bin/docker-compose pull ] ( virtualenv `.venv` )
                                                                                                      
Pulling postgres ... done
```

^ Check that it picks up on the existence of the docker-compose file to start pulling the DB.