### PR TITLE
Missing libraries to build wheels on Apple M1s

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotrun
 
-version: "1.4.3"
+version: "1.4.4"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -48,6 +48,7 @@ parts:
       - git
       - build-essential
       - python3-dev
+      - libc6-dev
       - libjpeg-dev
       - libjpeg-progs
       - libmagic1


### PR DESCRIPTION
The following issue was reported by @steverydz on his Apple M1: https://pastebin.canonical.com/p/Q6tjwNXZYC/

Looks like it could be because this library is missing to build Python wheels for the ruamel.yaml library.

## QA

Check out this branch and then:
```
snap remove --purge dotrun
snapcraft
snap install --dangerous dotrun_1.4.4_amd64.snap

sudo snap connect dotrun:dot-npmrc
sudo snap connect dotrun:dot-yarnrc
sudo snap connect dotrun:docker-executables docker:docker-executables
sudo snap connect dotrun:docker-cli docker:docker-daemon
```

Then `cd` to a project and try it.