### PR TITLE
Add dependencies for chromium (needed for the puppeteer NPM package)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: dotrun
 
-version: "1.4.4"
+version: "1.4.5"
 
 summary: A command-line tool for running Node.js and Python projects
 
@@ -58,6 +58,27 @@ parts:
       - gpg
       - optipng
       - zlib1g-dev
+      # Chromium dependencies (for puppeteer NPM package)
+      - libasound2
+      - libatk-bridge2.0-0
+      - libatk1.0-0
+      - libatspi2.0-0
+      - libcairo2
+      - libcups2
+      - libdrm2
+      - libgbm1
+      - libnss3
+      - libpango-1.0-0
+      - libx11-6
+      - libxau6
+      - libxcb1
+      - libxcomposite1
+      - libxdamage1
+      - libxdmcp6
+      - libxext6
+      - libxfixes3
+      - libxkbcommon-x11-0
+      - libxrandr2
 plugs:
   dot-npmrc:
     interface: personal-files
@@ -95,3 +116,4 @@ apps:
       - dot-yarnrc
       - docker-cli
       - docker-executables
+      - desktop


### PR DESCRIPTION
## Done

- Add the necessary dependencies for the chromium browser, as it's needed for Puppeteer (eventually Cypress as it uses puppeteer)

## QA

- Build the snap: `snapcraft`
- Install the generated snap: `sudo snap install dotrun_1.4.5_amd64.snap --dangerous --devmode`
- Create an empty project: `mkdir dotrun-test && cd dotrun-test`
- Run the following commands to setup the project:
```bash
yarn init -y
yarn add puppeteer
rm -rf node_modules
```
- Create a testing script:
```js
// test.js
const puppeteer = require('puppeteer');

(async () => {
  const browser = await puppeteer.launch();
  const page = await browser.newPage();
  await page.goto('https://ubuntu.com');
  await page.screenshot({ path: 'screenshot.png' });

  await browser.close();
})();
```
- Finally, run the project and make sure that the `screenshot.png` is generated :
```bash
dotrun install
dotrun exec node test.js
```
