### PR TITLE
Add plug for LXD

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,6 +95,8 @@ plugs:
     default-provider: docker
     interface: content
     target: docker-env
+  lxd:
+    interface: lxd
 
 apps:
   dotrun:


### PR DESCRIPTION
## Done

- Added plug for [LXD](https://snapcraft.io/docs/lxd-interface) to enable access to the LXD unix socket on the host

## QA

- Ensure that LXD is running and listening on `/var/snap/lxd/common/lxd/unix.socket`
- Build/install the snap:
  ```
  $ snapcraft
  $ sudo snap install --dangerous dotrun_1.4.5_amd64.snap
  $ sudo snap connect dotrun:lxd lxd:lxd
  ```
- Verify that the LXD socket is accessible from within the snap:
  ```
  $ echo "ls -l /var/snap/lxd/common/lxd/unix.socket" | snap run --shell dotrun
  ```