### PR TITLE
fix dead pr.yml link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This runs the same tests in the `tests` directory against an actual snap install
 
 ### Automated tests of pull requests
 
-[The "PR" action](.github/workflows/pr.yml) builds the snap and runs the `tests`, similar to the "multipass" solution above. This will run against every pull request.
+[The "PR" action](.github/workflows/pr.yaml) builds the snap and runs the `tests`, similar to the "multipass" solution above. This will run against every pull request.
 
 ### Publish
 


### PR DESCRIPTION
fix dead pr.yml link in README.md

## Before
https://github.com/canonical-web-and-design/dotrun/blob/main/.github/workflows/pr.yml

## After
https://github.com/canonical-web-and-design/dotrun/blob/main/.github/workflows/pr.yaml