### PR TITLE
fix: fix broken numbering of ordered list items in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ If you prefer to install manually or encounter any issues with the installation 
 
 2. Ensure `pipx` is in your PATH:
 
-```bash
-pipx ensurepath
-```
+    ```bash
+    pipx ensurepath
+    ```
 
-1. Install `dotrun` using `pipx`:
+3. Install `dotrun` using `pipx`:
 
-```bash
-pipx install dotrun
-```
+    ```bash
+    pipx install dotrun
+    ```
 
 If you experience problems, please open a GitHub issue.
 


### PR DESCRIPTION
This pull request fixes the following markup error:

<img width="844" height="424" alt="Screenshot" src="https://github.com/user-attachments/assets/a24bd5ea-45b8-4cc5-a7b1-9429fe7bf1ff" />
